### PR TITLE
add a upnp parameter to control the port-forwarding feature

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,7 @@ class transmission (
       $opt_auth = ''
     }
     cron { 'update-blocklist':
-      command => "/usr/bin/transmission-remote http://127.0.0.1:${web_port}/transmission/${opt_auth} --blocklist-update 2>&1 > /tmp/blocklist.log",
+      command => "/usr/bin/transmission-remote ${web_port} ${opt_auth} --blocklist-update 2>&1 > /tmp/blocklist.log",
       user    => root,
       hour    => 2,
       minute  => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class transmission (
   $speed_up           = $transmission::params::speed_up,
   $seed_queue_enabled = $transmission::params::seed_queue_enabled,
   $seed_queue_size    = $transmission::params::seed_queue_size,
+  $upnp               = $transmission::params::upnp,
 ) inherits transmission::params {
 
   $_settings_json = "${config_path}/settings.json"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,25 +1,30 @@
 # = Class: transmission
-# 
-# This class installs/configures/manages the transmission-daemon bittorrent client.
-# 
-# == Parameters: 
 #
-# $download_dir:: The directory where the files have to be downloaded. Defaults to +$config_path/downloads+.
-# $incomplete_dir:: The temporary directory used to store incomplete files. Disabled when the option is not set (this is the default).
+# This class installs/configures/manages the transmission-daemon bittorrent
+# client.
+#
+# == Parameters:
+#
+# $download_dir:: The directory where the files have to be downloaded. Defaults
+#   to +$config_path/downloads+.
+# $incomplete_dir:: The temporary directory used to store incomplete files.
+#   Disabled when the option is not set (this is the default).
 # $web_port:: The port the web server is listening on. Defaults to +9091+.
 # $web_user:: The web client login name. Defaults to +transmission+.
 # $web_password:: The password of the web client user (default: <none>)
-# $web_whitelist:: An array of IP addresses. This list define which machines are allowed to use the web interface. It is possible to use wildcards in the addresses. By default the list is empty.
+# $web_whitelist:: An array of IP addresses. This list define which machines
+#   are allowed to use the web interface. It is possible to use wildcards in the
+#   addresses. By default the list is empty.
 # $blocklist_url:: An url to a block list (default: <none>)
 # $package_name:: name of the package. Default to 'transmission-daemon'
 # $transmission_user:: default 'transmission'
 # $transmission_group:: default 'transmission'
 # $service_name:: default = $package_name
 #
-# == Requires: 
-# 
+# == Requires:
+#
 # Nothing.
-# 
+#
 # == Sample Usage:
 #
 #  class {'transmission':
@@ -55,12 +60,12 @@ class transmission (
 ) inherits transmission::params {
 
   $_settings_json = "${config_path}/settings.json"
-  
+
   $settings_tmp = '/tmp/transmission-settings.tmp'
-  
+
   package { 'transmission-daemon':
-    name   => $package_name,
     ensure => installed,
+    name   => $package_name,
   }
 
   # Find out the name of the transmission user/group
@@ -69,15 +74,19 @@ class transmission (
   # Transmission should be able to read the config dir
   file { $config_path:
     ensure   => directory,
-    group    => $transmission_group,            # We only set the group (the dir could be owned by root or someone ele)
-    mode     => 'g+rx',                         # Make sure transmission can access the config dir
-    require  => Package['transmission-daemon'], # Make sure that the package is installed and had the opportunity to create the directory first
+    # We only set the group (the dir could be owned by root or someone else)
+    group    => $transmission_group,
+    # Make sure transmission can access the config dir
+    mode     => 'g+rx',
+    # Make sure that the package is installed and had the opportunity to create
+    # the directory first
+    require  => Package['transmission-daemon'],
   }
 
   # The settings file should follow our template
   file { 'settings.json':
-    path    => $_settings_json,
     ensure  => file,
+    path    => $_settings_json,
     content => template("${module_name}/settings.json.erb"),
     mode    => 'u+rw',          # Make sure transmisson can r/w settings
     owner   => $transmission_user,
@@ -86,31 +95,43 @@ class transmission (
     notify  => Exec['activate-new-settings'],
   }
 
-  # Helper. To circumvent transmission's bad habit of rewriting 'settings.json' every now and then.
+  # Helper. To circumvent transmission's bad habit of rewriting 'settings.json'
+  # every now and then.
   exec { 'activate-new-settings':
-    refreshonly => true,        # Run only when another resource (File['settings.json']) tells us to do it
-    command     => "cp $_settings_json $settings_tmp; service $service_name stop; sleep 5; cat $settings_tmp > $_settings_json; chmod u+r $_settings_json",
+    refreshonly => true,        # Run only when another resource
+                                # (File['settings.json']) tells us to do it
+    command     => "cp ${_settings_json} ${settings_tmp}; service ${service_name} stop; sleep 5; cat ${settings_tmp} > ${_settings_json}; chmod u+r ${_settings_json}",
     path        => ['/bin','/sbin', '/usr/sbin'],
-    notify      => Service['transmission-daemon'], # Now we can tell the service about the changes // Start service
+    # Now we can tell the service about the changes // Start service
+    notify      => Service['transmission-daemon'],
   }
 
 
   # Transmission should use the settings in ${config_path}/settings.json *only*
   # This is ugly, but necessary
   file {['/etc/default/transmission','/etc/sysconfig/transmission']:
-    ensure  => absent,                         # Kill the bastards
-    require => Package['transmission-daemon'], # The package has to be installed first. Otherwise this would be sheer folly.
-    before  => Service['transmission-daemon'], # After this is fixed, we can handle the service
+    # Kill the bastards
+    ensure  => absent,
+    # The package has to be installed first. Otherwise this would be sheer
+    # folly.
+    require => Package['transmission-daemon'],
+    # After this is fixed, we can handle the service
+    before  => Service['transmission-daemon'],
   }
-    
-  # Manage the download directory.  Creating parents will be taken care of "upstream" (in the calling class)
+
+  # Manage the download directory.  Creating parents will be taken care of
+  # "upstream" (in the calling class)
   file { $download_dir:
     ensure  => directory,
-    #recurse => true,  # Broken. Creates invalid resurce tags for some downloaded files with funny characters.
+    # Broken. Creates invalid resurce tags for some downloaded files with funny
+    # characters.
+    #recurse => true,
     owner   => $transmission_user,
     group   => $transmission_group,
     mode    => 'ug+rw,u+x',
-    require => Package['transmission-daemon'], # Let's give the installer a chance to create the directory and user before we manage this dir
+    # Let's give the installer a chance to create the directory and user before
+    # we manage this dir
+    require => Package['transmission-daemon'],
   }
 
   # directory for partial downloads
@@ -127,8 +148,8 @@ class transmission (
 
   # Keep the service running
   service { 'transmission-daemon':
-    name       => $service_name,
     ensure     => running,
+    name       => $service_name,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
@@ -142,7 +163,7 @@ class transmission (
     }
     else
     {
-      $opt_auth = ""
+      $opt_auth = ''
     }
     cron { 'update-blocklist':
       command => "/usr/bin/transmission-remote http://127.0.0.1:${web_port}/transmission/${opt_auth} --blocklist-update 2>&1 > /tmp/blocklist.log",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,5 @@ class transmission::params {
   $speed_up           = undef # undef=Unlimited
   $seed_queue_enabled = true
   $seed_queue_size    = 10
+  $upnp               = false
 }

--- a/templates/settings.json.erb
+++ b/templates/settings.json.erb
@@ -36,7 +36,7 @@
     "peer-port-random-on-start": false, 
     "peer-socket-tos": 0, 
     "pex-enabled": true, 
-    "port-forwarding-enabled": false, 
+    "port-forwarding-enabled": <%= @upnp %>,
     "preallocation": 1, 
     "prefetch-enabled": 1, 
     "queue-stalled-enabled": true, 


### PR DESCRIPTION
The upnp feature is off by default in the current settings template. This adds a parameter to control it.
