### PR TITLE
Bugfix: sysconfig + puppet-lint compliant code

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,2 @@
+--no-80chars-check
+--no-class_inherits_from_params_class-check

--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
-transmission
+# transmission
 
 This module manages the transmission bittorrent daemon.
 
-
-License
--------
+# License
 
 
-Contact
--------
+# Contact
 
 https://github.com/Magmatrix/transmission
 
-Support
--------
-
+# Support

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -1,5 +1,7 @@
+# Class: transmission::debian
+#
 class transmission::debian {
-  if $osfamily == 'Debian' { #check for sanity
+  if $::osfamily == 'Debian' {
     file { '/etc/default/transmission-daemon':
       ensure  => file,
       content => 'ENABLE_DAEMON=0',

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -1,9 +1,12 @@
+# Class: transmission::redhat
+#
 class transmission::redhat {
-  if $osfamily == 'RedHat' { #check for sanity
+  if $::osfamily == 'RedHat' {
     file { '/etc/sysconfig/transmission-daemon':
       ensure  => file,
-      content => 'DAEMON_ARGS="-e /var/log/transmission-daemon.log"',
+      content => "DAEMON_ARGS=\"-T --blocklist -g ${::transmission::config_path}\"",
       before  => Service['transmission-daemon'],
+      notify  => Service['transmission-daemon'],
     }
   }
 }


### PR DESCRIPTION
I stumbled upon an issue with the sysconfig on a CentOS based system. 

The init script provided by the rpm package is setting a default config path. Which can only be overridden by the sysconfig file. In the current state of your module the case operating system was missing so the sysconfig files were not placed on the machine. Therefore the initialized configuration by puppet was never seen by the transmission-daemon..

So I added a case statement based on OS to actually place the sysconfig file with the config_path param.

I did not changed it yet but I do believe it would be a better idea to add an actual default config_path value instead of undef. That way your module is able to run without setting any parameter and more clear to user to deal with it?

Greetz
