### PR TITLE
Feature: adding a default value for the config_path param

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # Default Parameter values
 
 class transmission::params {
-  $config_path        = undef
+  $config_path        = '/opt/transmission'
   $download_dir       = '/downloads'
   $incomplete_dir     = undef
   $blocklist_url      = undef


### PR DESCRIPTION
Hi,

as discussed on https://github.com/Magmatrix/transmission/pull/4 I changed the default value of the config_path param to an actual path instead of undef. 

This way your module is usable through only one include ::transmission with a set of default parameters!
